### PR TITLE
Fix merge conflicts with current compose master

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # Contributing to Compose
 
-Compose is a part of the Docker project, and follows the same rules and principles. Take a read of [Docker's contributing guidelines](https://github.com/docker/docker/blob/master/CONTRIBUTING.md) to get an overview.
+Compose is a part of the Docker project, and follows the same rules and
+principles. Take a read of [Docker's contributing guidelines](https://github.com/docker/docker/blob/master/CONTRIBUTING.md)
+to get an overview.
 
 ## TL;DR
 
@@ -17,27 +19,39 @@ If you're looking contribute to Compose
 but you're new to the project or maybe even to Python, here are the steps
 that should get you started.
 
-1. Fork [https://github.com/docker/compose](https://github.com/docker/compose) to your username.
-1. Clone your forked repository locally `git clone git@github.com:yourusername/compose.git`.
-1. Enter the local directory `cd compose`.
-1. Set up a development environment by running `python setup.py develop`. This will install the dependencies and set up a symlink from your `docker-compose` executable to the checkout of the repository. When you now run `docker-compose` from anywhere on your machine, it will run your development version of Compose.
+1. Fork [https://github.com/docker/compose](https://github.com/docker/compose)
+   to your username.
+2. Clone your forked repository locally `git clone git@github.com:yourusername/compose.git`.
+3. Enter the local directory `cd compose`.
+4. Set up a development environment by running `python setup.py develop`. This
+   will install the dependencies and set up a symlink from your `docker-compose`
+   executable to the checkout of the repository. When you now run
+   `docker-compose` from anywhere on your machine, it will run your development
+   version of Compose.
 
 ## Running the test suite
 
-Use the test script to run DCO check, linting checks and then the full test suite against different Python interpreters:
+Use the test script to run DCO check, linting checks and then the full test
+suite against different Python interpreters:
 
     $ script/test
 
-Tests are run against a Docker daemon inside a container, so that we can test against multiple Docker versions. By default they'll run against only the latest Docker version - set the `DOCKER_VERSIONS` environment variable to "all" to run against all supported versions:
+Tests are run against a Docker daemon inside a container, so that we can test
+against multiple Docker versions. By default they'll run against only the latest
+Docker version - set the `DOCKER_VERSIONS` environment variable to "all" to run
+against all supported versions:
 
     $ DOCKER_VERSIONS=all script/test
 
-Arguments to `script/test` are passed through to the `nosetests` executable, so you can specify a test directory, file, module, class or method:
+Arguments to `script/test` are passed through to the `nosetests` executable, so
+you can specify a test directory, file, module, class or method:
 
     $ script/test tests/unit
     $ script/test tests/unit/cli_test.py
     $ script/test tests.integration.service_test
     $ script/test tests.integration.service_test:ServiceTest.test_containers
+
+Before pushing a commit you can check the DCO by invoking `script/validate-dco`.
 
 ## Building binaries
 
@@ -49,27 +63,23 @@ OS X:
 
     $ script/build-osx
 
-Note that this only works on Mountain Lion, not Mavericks, due to a [bug in PyInstaller](http://www.pyinstaller.org/ticket/807).
+Note that this only works on Mountain Lion, not Mavericks, due to a
+[bug in PyInstaller](http://www.pyinstaller.org/ticket/807).
 
 ## Release process
 
 1. Open pull request that:
-
  - Updates the version in `compose/__init__.py`
  - Updates the binary URL in `docs/install.md`
  - Updates the script URL in `docs/completion.md`
  - Adds release notes to `CHANGES.md`
-
 2. Create unpublished GitHub release with release notes
-
-3. Build Linux version on any Docker host with `script/build-linux` and attach to release
-
-4. Build OS X version on Mountain Lion with `script/build-osx` and attach to release as `docker-compose-Darwin-x86_64` and `docker-compose-Linux-x86_64`.
-
+3. Build Linux version on any Docker host with `script/build-linux` and attach
+   to release
+4. Build OS X version on Mountain Lion with `script/build-osx` and attach to
+   release as `docker-compose-Darwin-x86_64` and `docker-compose-Linux-x86_64`.
 5. Publish GitHub release, creating tag
-
 6. Update website with `script/deploy-docs`
-
 7. Upload PyPi package
 
         $ git checkout $VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,18 +24,14 @@ RUN set -x \
  && rm -rf /var/lib/apt/lists/* \
  && curl -SsL 'https://bootstrap.pypa.io/get-pip.py' | python
 
-ENV ALL_DOCKER_VERSIONS 1.3.3 1.4.1 1.5.0 1.6.0-rc2
+ENV ALL_DOCKER_VERSIONS 1.6.0-rc4
 
- RUN set -ex; \
-     for v in 1.3.3 1.4.1 1.5.0; do \
-         curl -Ss https://get.docker.com/builds/Linux/x86_64/docker-$v -o /usr/local/bin/docker-$v; \
-         chmod +x /usr/local/bin/docker-$v; \
-     done; \
-     curl -Ss https://test.docker.com/builds/Linux/x86_64/docker-1.6.0-rc2 -o /usr/local/bin/docker-1.6.0-rc2; \
-     chmod +x /usr/local/bin/docker-1.6.0-rc2
+RUN set -ex; \
+    curl https://test.docker.com/builds/Linux/x86_64/docker-1.6.0-rc4 -o /usr/local/bin/docker-1.6.0-rc4; \
+    chmod +x /usr/local/bin/docker-1.6.0-rc4
 
 # Set the default Docker to be run
-RUN ln -s /usr/local/bin/docker-1.3.3 /usr/local/bin/docker
+RUN ln -s /usr/local/bin/docker-1.6.0-rc4 /usr/local/bin/docker
 
 WORKDIR /code
 ADD requirements*.txt tox.ini ./

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 Docker Compose
 ==============
-[![Build Status](http://jenkins.dockerproject.com/buildStatus/icon?job=Compose Master)](http://jenkins.dockerproject.com/job/Compose%20Master/)
 *(Previously known as Fig)*
 
 Compose is a tool for defining and running complex applications with Docker.
@@ -53,3 +52,11 @@ Installation and documentation
 
 - Full documentation is available on [Docker's website](http://docs.docker.com/compose/).
 - Hop into #docker-compose on Freenode if you have any questions.
+
+Contributing
+------------
+
+[![Build Status](http://jenkins.dockerproject.com/buildStatus/icon?job=Compose Master)](http://jenkins.dockerproject.com/job/Compose%20Master/)
+
+Want to help build Compose? Check out our [contributing documentation](https://github.com/docker/compose/blob/master/CONTRIBUTING.md).
+

--- a/compose/service.py
+++ b/compose/service.py
@@ -2,9 +2,8 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from collections import namedtuple
 import logging
-import os
-from operator import attrgetter
 import re
+from operator import attrgetter
 import sys
 import six
 
@@ -25,6 +24,7 @@ DOCKER_START_KEYS = [
     'dns_search',
     'env_file',
     'net',
+    'pid',
     'privileged',
     'restart',
 ]
@@ -434,6 +434,7 @@ class Service(object):
         privileged = options.get('privileged', False)
         cap_add = options.get('cap_add', None)
         cap_drop = options.get('cap_drop', None)
+        pid = options.get('pid', None)
 
         dns = options.get('dns', None)
         if isinstance(dns, six.string_types):
@@ -457,6 +458,7 @@ class Service(object):
             restart_policy=restart,
             cap_add=cap_add,
             cap_drop=cap_drop,
+            pid_mode=pid
         )
 
     def _get_image_name(self, image):
@@ -586,8 +588,7 @@ def parse_repository_tag(s):
 
 def build_volume_binding(volume_spec):
     internal = {'bind': volume_spec.internal, 'ro': volume_spec.mode == 'ro'}
-    external = os.path.expanduser(volume_spec.external)
-    return os.path.abspath(os.path.expandvars(external)), internal
+    return volume_spec.external, internal
 
 
 def build_port_bindings(ports):

--- a/docs/extends.md
+++ b/docs/extends.md
@@ -1,0 +1,364 @@
+page_title: Extending services in Compose
+page_description: How to use Docker Compose's "extends" keyword to share configuration between files and projects
+page_keywords: fig, composition, compose, docker, orchestration, documentation, docs
+
+
+## Extending services in Compose
+
+Docker Compose's `extends` keyword enables sharing of common configurations
+among different files, or even different projects entirely. Extending services
+is useful if you have several applications that reuse commonly-defined services.
+Using `extends` you can define a service in one place and refer to it from
+anywhere.
+
+Alternatively, you can deploy the same application to multiple environments with
+a slightly different set of services in each case (or with changes to the
+configuration of some services). Moreover, you can do so without copy-pasting
+the configuration around.
+
+### Understand the extends configuration
+
+When defining any service in `docker-compose.yml`, you can declare that you are
+extending another service like this:
+
+```yaml
+web:
+  extends:
+    file: common-services.yml
+    service: webapp
+```
+
+This instructs Compose to re-use the configuration for the `webapp` service
+defined in the `common-services.yml` file. Suppose that `common-services.yml`
+looks like this:
+
+```yaml
+webapp:
+  build: .
+  ports:
+    - "8000:8000"
+  volumes:
+    - "/data"
+```
+
+In this case, you'll get exactly the same result as if you wrote
+`docker-compose.yml` with that `build`, `ports` and `volumes` configuration
+defined directly under `web`.
+
+You can go further and define (or re-define) configuration locally in
+`docker-compose.yml`:
+
+```yaml
+web:
+  extends:
+    file: common-services.yml
+    service: webapp
+  environment:
+    - DEBUG=1
+  cpu_shares: 5
+```
+
+You can also write other services and link your `web` service to them:
+
+```yaml
+web:
+  extends:
+    file: common-services.yml
+    service: webapp
+  environment:
+    - DEBUG=1
+  cpu_shares: 5
+  links:
+    - db
+db:
+  image: postgres
+```
+
+For full details on how to use `extends`, refer to the [reference](#reference).
+
+### Example use case
+
+In this example, you’ll repurpose the example app from the [quick start
+guide](index.md). (If you're not familiar with Compose, it's recommended that
+you go through the quick start first.) This example assumes you want to use
+Compose both to develop an application locally and then deploy it to a
+production environment.
+
+The local and production environments are similar, but there are some
+differences. In development, you mount the application code as a volume so that
+it can pick up changes; in production, the code should be immutable from the
+outside. This ensures it’s not accidentally changed. The development environment
+uses a local Redis container, but in production another team manages the Redis
+service, which is listening at `redis-production.example.com`.
+
+To configure with `extends` for this sample, you must:
+
+1.  Define the web application as a Docker image in `Dockerfile` and a Compose
+    service in `common.yml`.
+
+2.  Define the development environment in the standard Compose file,
+    `docker-compose.yml`.
+
+    - Use `extends` to pull in the web service.
+    - Configure a volume to enable code reloading.
+    - Create an additional Redis service for the application to use locally.
+
+3.  Define the production environment in a third Compose file, `production.yml`.
+
+    - Use `extends` to pull in the web service.
+    - Configure the web service to talk to the external, production Redis service.
+
+#### Define the web app
+
+Defining the web application requires the following:
+
+1.  Create an `app.py` file.
+
+    This file contains a simple Python application that uses Flask to serve HTTP
+    and increments a counter in Redis:
+
+        from flask import Flask
+        from redis import Redis
+        import os
+
+        app = Flask(__name__)
+        redis = Redis(host=os.environ['REDIS_HOST'], port=6379)
+
+        @app.route('/')
+        def hello():
+           redis.incr('hits')
+           return 'Hello World! I have been seen %s times.\n' % redis.get('hits')
+
+        if __name__ == "__main__":
+           app.run(host="0.0.0.0", debug=True)
+
+    This code uses a `REDIS_HOST` environment variable to determine where to
+    find Redis.
+
+2.  Define the Python dependencies in a `requirements.txt` file:
+
+        flask
+        redis
+
+3.  Create a `Dockerfile` to build an image containing the app:
+
+        FROM python:2.7
+        ADD . /code
+        WORKDIR /code
+        RUN pip install -r
+        requirements.txt
+        CMD python app.py
+
+4.  Create a Compose configuration file called `common.yml`:
+
+    This configuration defines how to run the app.
+
+        web:
+          build: .
+          ports:
+            - "5000:5000"
+
+    Typically, you would have dropped this configuration into
+    `docker-compose.yml` file, but in order to pull it into multiple files with
+    `extends`, it needs to be in a separate file.
+
+#### Define the development environment
+
+1.  Create a `docker-compose.yml` file.
+
+    The `extends` option pulls in the `web` service from the `common.yml` file
+    you created in the previous section.
+
+        web:
+          extends:
+            file: common.yml
+            service: web
+          volumes:
+            - .:/code
+          links:
+            - redis
+          environment:
+            - REDIS_HOST=redis
+        redis:
+          image: redis
+
+    The new addition defines a `web` service that:
+
+    - Fetches the base configuration for `web` out of `common.yml`.
+    - Adds `volumes` and `links` configuration to the base (`common.yml`)
+    configuration.
+    - Sets the `REDIS_HOST` environment variable to point to the linked redis
+    container. This environment uses a stock `redis` image from the Docker Hub.
+
+2.  Run `docker-compose up`.
+
+    Compose creates, links, and starts a web and redis container linked together.
+    It mounts your application code inside the web container.
+
+3.  Verify that the code is mounted by changing the message in
+    `app.py`&mdash;say, from `Hello world!` to `Hello from Compose!`.
+
+    Don't forget to refresh your browser to see the change!
+
+#### Define the production environment
+
+You are almost done. Now, define your production environment:
+
+1.  Create a `production.yml` file.
+
+    As with `docker-compose.yml`, the `extends` option pulls in the `web` service
+    from `common.yml`.
+
+        web:
+          extends:
+            file: common.yml
+            service: web
+          environment:
+            - REDIS_HOST=redis-production.example.com
+
+2.  Run `docker-compose -f production.yml up`.
+
+    Compose creates *just* a web container and configures the Redis connection via
+    the `REDIS_HOST` environment variable. This variable points to the production
+    Redis instance.
+
+    > **Note**: If you try to load up the webapp in your browser you'll get an
+    > error&mdash;`redis-production.example.com` isn't actually a Redis server.
+
+You've now done a basic `extends` configuration. As your application develops,
+you can make any necessary changes to the web service in `common.yml`. Compose
+picks up both the development and production environments when you next run
+`docker-compose`. You don't have to do any copy-and-paste, and you don't have to
+manually keep both environments in sync.
+
+
+### Reference
+
+You can use `extends` on any service together with other configuration keys. It
+always expects a dictionary that should always contain two keys: `file` and
+`service`.
+
+The `file` key specifies which file to look in. It can be an absolute path or a
+relative one&mdash;if relative, it's treated as relative to the current file.
+
+The `service` key specifies the name of the service to extend, for example `web`
+or `database`.
+
+You can extend a service that itself extends another. You can extend
+indefinitely. Compose does not support circular references and `docker-compose`
+returns an error if it encounters them.
+
+#### Adding and overriding configuration
+
+Compose copies configurations from the original service over to the local one,
+**except** for `links` and `volumes_from`. These exceptions exist to avoid
+implicit dependencies&mdash;you always define `links` and `volumes_from`
+locally. This ensures dependencies between services are clearly visible when
+reading the current file. Defining these locally also ensures changes to the
+referenced file don't result in breakage.
+
+If a configuration option is defined in both the original service and the local
+service, the local value either *override*s or *extend*s the definition of the
+original service. This works differently for other configuration options.
+
+For single-value options like `image`, `command` or `mem_limit`, the new value
+replaces the old value. **This is the default behaviour - all exceptions are
+listed below.**
+
+```yaml
+# original service
+command: python app.py
+
+# local service
+command: python otherapp.py
+
+# result
+command: python otherapp.py
+```
+
+In the case of `build` and `image`, using one in the local service causes
+Compose to discard the other, if it was defined in the original service.
+
+```yaml
+# original service
+build: .
+
+# local service
+image: redis
+
+# result
+image: redis
+```
+
+```yaml
+# original service
+image: redis
+
+# local service
+build: .
+
+# result
+build: .
+```
+
+For the **multi-value options** `ports`, `expose`, `external_links`, `dns` and
+`dns_search`, Compose concatenates both sets of values:
+
+```yaml
+# original service
+expose:
+  - "3000"
+
+# local service
+expose:
+  - "4000"
+  - "5000"
+
+# result
+expose:
+  - "3000"
+  - "4000"
+  - "5000"
+```
+
+In the case of `environment`, Compose "merges" entries together with
+locally-defined values taking precedence:
+
+```yaml
+# original service
+environment:
+  - FOO=original
+  - BAR=original
+
+# local service
+environment:
+  - BAR=local
+  - BAZ=local
+
+# result
+environment:
+  - FOO=original
+  - BAR=local
+  - BAZ=local
+```
+
+Finally, for `volumes`, Compose "merges" entries together with locally-defined
+bindings taking precedence:
+
+```yaml
+# original service
+volumes:
+  - /original-dir/foo:/foo
+  - /original-dir/bar:/bar
+
+# local service
+volumes:
+  - /local-dir/bar:/bar
+  - /local-dir/baz/:baz
+
+# result
+volumes:
+  - /original-dir/foo:/foo
+  - /local-dir/bar:/bar
+  - /local-dir/baz/:baz
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,8 @@ page_keywords: documentation, docs,  docker, compose, orchestration, containers
 
 # Docker Compose
 
+## Overview
+
 Compose is a tool for defining and running complex applications with Docker.
 With Compose, you define a multi-container application in a single file, then
 spin your application up in a single command which does everything that needs to
@@ -191,3 +193,17 @@ At this point, you have seen the basics of how Compose works.
   [Rails](rails.md), or [Wordpress](wordpress.md).
 - See the reference guides for complete details on the [commands](cli.md), the
   [configuration file](yml.md) and [environment variables](env.md).
+  
+## Release Notes
+
+### Version 1.2.0 (April 7, 2015)
+
+For complete information on this release, see the [1.2.0 Milestone project page](https://github.com/docker/compose/wiki/1.2.0-Milestone-Project-Page).
+In addition to bug fixes and refinements, this release adds the following:
+
+* The `extends` keyword, which adds the ability to extend services by sharing  common configurations. For details, see
+[PR #972](https://github.com/docker/compose/pull/1088).
+
+* Better integration with Swarm. Swarm will now schedule inter-dependent
+containers on the same host. For details, see
+[PR #972](https://github.com/docker/compose/pull/972).

--- a/docs/install.md
+++ b/docs/install.md
@@ -23,6 +23,8 @@ To install Compose, run the following commands:
     curl -L https://github.com/docker/compose/releases/download/1.1.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
     chmod +x /usr/local/bin/docker-compose
 
+> Note: If you get a "Permission denied" error, your `/usr/local/bin` directory probably isn't writable and you'll need to install Compose as the superuser. Run `sudo -i`, then the two commands above, then `exit`.
+
 Optionally, you can also install [command completion](completion.md) for the
 bash shell.
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,5 +1,7 @@
 
 - ['compose/index.md', 'User Guide', 'Docker Compose' ]
+- ['compose/production.md', 'User Guide', 'Using Compose in production' ]
+- ['compose/extends.md', 'User Guide', 'Extending services in Compose']
 - ['compose/install.md', 'Installation', 'Docker Compose']
 - ['compose/cli.md', 'Reference', 'Compose command line']
 - ['compose/yml.md', 'Reference', 'Compose yml']

--- a/docs/production.md
+++ b/docs/production.md
@@ -1,0 +1,77 @@
+page_title: Using Compose in production
+page_description: Guide to using Docker Compose in production
+page_keywords: documentation, docs,  docker, compose, orchestration, containers, production
+
+
+## Using Compose in production
+
+While **Compose is not yet considered production-ready**, if you'd like to experiment and learn more about using it in production deployments, this guide
+can help.
+The project is actively working towards becoming
+production-ready; to learn more about the progress being made, check out the
+[roadmap](https://github.com/docker/compose/blob/master/ROADMAP.md) for details
+on how it's coming along and what still needs to be done.
+
+When deploying to production, you'll almost certainly want to make changes to
+your app configuration that are more appropriate to a live environment. These
+changes may include:
+
+- Removing any volume bindings for application code, so that code stays inside
+  the container and can't be changed from outside
+- Binding to different ports on the host
+- Setting environment variables differently (e.g., to decrease the verbosity of
+  logging, or to enable email sending)
+- Specifying a restart policy (e.g., `restart: always`) to avoid downtime
+- Adding extra services (e.g., a log aggregator)
+
+For this reason, you'll probably want to define a separate Compose file, say
+`production.yml`, which specifies production-appropriate configuration.
+
+> **Note:** The [extends](extends.md) keyword is useful for maintaining multiple
+> Compose files which re-use common services without having to manually copy and
+> paste.
+
+Once you've got an alternate configuration file, make Compose use it
+by setting the `COMPOSE_FILE` environment variable:
+
+    $ COMPOSE_FILE=production.yml
+    $ docker-compose up -d
+
+> **Note:** You can also use the file for a one-off command without setting
+> an environment variable. You do this by passing the `-f` flag, e.g.,
+> `docker-compose -f production.yml up -d`.
+
+### Deploying changes
+
+When you make changes to your app code, you'll need to rebuild your image and
+recreate your app's containers. To redeploy a service called
+`web`, you would use:
+
+    $ docker-compose build web
+    $ docker-compose up --no-deps -d web
+
+This will first rebuild the image for `web` and then stop, destroy, and recreate
+*just* the `web` service. The `--no-deps` flag prevents Compose from also
+recreating any services which `web` depends on.
+
+### Running Compose on a single server
+
+You can use Compose to deploy an app to a remote Docker host by setting the
+`DOCKER_HOST`, `DOCKER_TLS_VERIFY`, and `DOCKER_CERT_PATH` environment variables
+appropriately. For tasks like this,
+[Docker Machine](https://docs.docker.com/machine) makes managing local and
+remote Docker hosts very easy, and is recommended even if you're not deploying
+remotely.
+
+Once you've set up your environment variables, all the normal `docker-compose`
+commands will work with no further configuration.
+
+### Running Compose on a Swarm cluster
+
+[Docker Swarm](https://docs.docker.com/swarm), a Docker-native clustering
+system, exposes the same API as a single Docker host, which means you can use
+Compose against a Swarm instance and run your apps across multiple hosts.
+
+Compose/Swarm integration is still in the experimental stage, and Swarm is still
+in beta, but if you'd like to explore and experiment, check out the
+[integration guide](https://github.com/docker/compose/blob/master/SWARM.md).

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -29,8 +29,9 @@ image: a4bc65fd
 
 ### build
 
-Path to a directory containing a Dockerfile. This directory is also the
-build context that is sent to the Docker daemon.
+Path to a directory containing a Dockerfile. When the value supplied is a 
+relative path, it is interpreted as relative to the location of the yml file 
+itself. This directory is also the build context that is sent to the Docker daemon.
 
 Compose will build and tag it with a generated name, and use that image thereafter.
 
@@ -172,8 +173,12 @@ env_file:
   - /opt/secrets.env
 ```
 
+Compose expects each line in an env file to be in `VAR=VAL` format. Lines
+beginning with `#` (i.e. comments) are ignored, as are blank lines.
+
 ```
-RACK_ENV: development
+# Set Rails/Rack environment
+RACK_ENV=development
 ```
 
 ### extends
@@ -216,42 +221,10 @@ Here, the `web` service in **development.yml** inherits the configuration of
 the `webapp` service in **common.yml** - the `build` and `environment` keys -
 and adds `ports` and `links` configuration. It overrides one of the defined
 environment variables (DEBUG) with a new value, and the other one
-(SEND_EMAILS) is left untouched. It's exactly as if you defined `web` like
-this:
+(SEND_EMAILS) is left untouched.
 
-```yaml
-web:
-  build: ./webapp
-  ports:
-    - "8000:8000"
-  links:
-    - db
-  environment:
-    - DEBUG=true
-    - SEND_EMAILS=false
-```
-
-The `extends` option is great for sharing configuration between different
-apps, or for configuring the same app differently for different environments.
-You could write a new file for a staging environment, **staging.yml**, which
-binds to a different port and doesn't turn on debugging:
-
-```
-web:
-  extends:
-    file: common.yml
-    service: webapp
-  ports:
-    - "80:8000"
-  links:
-    - db
-db:
-  image: postgres
-```
-
-> **Note:** When you extend a service, `links` and `volumes_from`
-> configuration options are **not** inherited - you will have to define
-> those manually each time you extend it.
+For more on `extends`, see the [tutorial](extends.md#example) and
+[reference](extends.md#reference).
 
 ### net
 
@@ -263,6 +236,16 @@ net: "none"
 net: "container:[name or id]"
 net: "host"
 ```
+### pid
+
+```
+pid: "host"
+```
+
+Sets the PID mode to the host PID mode.  This turns on sharing between
+container and the host operating system the PID address space.  Containers
+launched with this flag will be able to access and manipulate other
+containers in the bare-metal machine's namespace and vise-versa.
 
 ### dns
 

--- a/script/test-versions
+++ b/script/test-versions
@@ -8,7 +8,7 @@ set -e
 flake8 compose tests setup.py
 
 if [ "$DOCKER_VERSIONS" == "" ]; then
-  DOCKER_VERSIONS="1.5.0"
+  DOCKER_VERSIONS="default"
 elif [ "$DOCKER_VERSIONS" == "all" ]; then
   DOCKER_VERSIONS="$ALL_DOCKER_VERSIONS"
 fi

--- a/script/wrapdocker
+++ b/script/wrapdocker
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-if [ "$DOCKER_VERSION" == "" ]; then
-    DOCKER_VERSION="1.5.0"
+if [ "$DOCKER_VERSION" != "" ] && [ "$DOCKER_VERSION" != "default" ]; then
+    ln -fs "/usr/local/bin/docker-$DOCKER_VERSION" "/usr/local/bin/docker"
 fi
-
-ln -fs "/usr/local/bin/docker-$DOCKER_VERSION" "/usr/local/bin/docker"
 
 # If a pidfile is still around (for example after a container restart),
 # delete it so that docker can start.

--- a/tests/fixtures/build-ctx/Dockerfile
+++ b/tests/fixtures/build-ctx/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox:latest
+CMD echo "success"

--- a/tests/fixtures/build-path/docker-compose.yml
+++ b/tests/fixtures/build-path/docker-compose.yml
@@ -1,0 +1,2 @@
+foo:
+  build: ../build-ctx/

--- a/tests/fixtures/dockerfile_with_entrypoint/docker-compose.yml
+++ b/tests/fixtures/dockerfile_with_entrypoint/docker-compose.yml
@@ -1,2 +1,2 @@
 service:
-  build: tests/fixtures/dockerfile_with_entrypoint
+  build: .

--- a/tests/fixtures/simple-dockerfile/docker-compose.yml
+++ b/tests/fixtures/simple-dockerfile/docker-compose.yml
@@ -1,2 +1,2 @@
 simple:
-  build: tests/fixtures/simple-dockerfile
+  build: .

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -124,6 +124,24 @@ class ServiceTest(DockerClientTestCase):
         self.assertTrue(path.basename(actual_host_path) == path.basename(host_path),
                         msg=("Last component differs: %s, %s" % (actual_host_path, host_path)))
 
+    @mock.patch.dict(os.environ)
+    def test_create_container_with_home_and_env_var_in_volume_path(self):
+        os.environ['VOLUME_NAME'] = 'my-volume'
+        os.environ['HOME'] = '/tmp/home-dir'
+        expected_host_path = os.path.join(os.environ['HOME'], os.environ['VOLUME_NAME'])
+
+        host_path = '~/${VOLUME_NAME}'
+        container_path = '/container-path'
+
+        service = self.create_service('db', volumes=['%s:%s' % (host_path, container_path)])
+        container = service.create_container()
+        service.start_container(container)
+
+        actual_host_path = container.get('Volumes')[container_path]
+        components = actual_host_path.split('/')
+        self.assertTrue(components[-2:] == ['home-dir', 'my-volume'],
+                        msg="Last two components differ: %s, %s" % (actual_host_path, expected_host_path))
+
     def test_create_container_with_volumes_from(self):
         volume_service = self.create_service('data')
         volume_container_1 = volume_service.create_container()
@@ -419,6 +437,16 @@ class ServiceTest(DockerClientTestCase):
         service = self.create_service('web', net='host')
         container = create_and_start_container(service)
         self.assertEqual(container.get('HostConfig.NetworkMode'), 'host')
+
+    def test_pid_mode_none_defined(self):
+        service = self.create_service('web', pid=None)
+        container = create_and_start_container(service)
+        self.assertEqual(container.get('HostConfig.PidMode'), '')
+
+    def test_pid_mode_host(self):
+        service = self.create_service('web', pid='host')
+        container = create_and_start_container(service)
+        self.assertEqual(container.get('HostConfig.PidMode'), 'host')
 
     def test_dns_no_value(self):
         service = self.create_service('web')

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
-import os
 
 from .. import unittest
 from .. import mock
@@ -304,17 +303,3 @@ class ServiceVolumesTest(unittest.TestCase):
         self.assertEqual(
             binding,
             ('/outside', dict(bind='/inside', ro=False)))
-
-    @mock.patch.dict(os.environ)
-    def test_build_volume_binding_with_environ(self):
-        os.environ['VOLUME_PATH'] = '/opt'
-        binding = build_volume_binding(parse_volume_spec('${VOLUME_PATH}:/opt'))
-        self.assertEqual(binding, ('/opt', dict(bind='/opt', ro=False)))
-
-    @mock.patch.dict(os.environ)
-    def test_building_volume_binding_with_home(self):
-        os.environ['HOME'] = '/home/user'
-        binding = build_volume_binding(parse_volume_spec('~:/home/user'))
-        self.assertEqual(
-            binding,
-            ('/home/user', dict(bind='/home/user', ro=False)))


### PR DESCRIPTION
All tests run by `script/test` pass locally.

```
___________________________________ summary ____________________________________
  py26: commands succeeded
  py27: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
  pypy: commands succeeded
```